### PR TITLE
Define STRICT_R_HEADERS, include cfloat for DBL_EPSILON

### DIFF
--- a/src/Cpp_code.cpp
+++ b/src/Cpp_code.cpp
@@ -1,8 +1,10 @@
 //// Cpp functions 2015-3-11 Thong Pham
+#define STRICT_R_HEADERS
 #include <Rcpp.h>
 #include <iostream>    
 #include <algorithm>    
 #include <vector>      
+#include <cfloat>
 
 using namespace Rcpp;
 


### PR DESCRIPTION
Dear Thong, dear PAFit team,

Your CRAN package PAFit uses Rcpp, and is affected if we add a definition of STRICT_R_HEADERS as we would like to do. Please see the discussion at https://github.com/RcppCore/Rcpp/issues/1158 and the links therein for more context on this.

Here we prefixing one #include <Rcpp.h> with STRICT_R_HEADERS and include cfloat (or float.h, C style) in one file so that DBL_EPSILON (and LDL_EPISLON) are defined. No other changes were made. 

It would be lovely if you could apply this. There is no strong urgency: we aim to get this done over all affected packages in the space of a few months. If you apply it, would you mind dropping me a note by email or swinging by https://github.com/RcppCore/Rcpp/issues/1158 to confirm?

Many thanks for your help, and I hope you continue to find Rcpp helpful. Please don't hesitate to ask if you have any questions.
